### PR TITLE
BUG Fixed dependencies to point to correct mollom package

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 * SilverStripe >= 3.1  
 * Silverstripe SpamProtection module
+* Mollom REST PHP Client <https://github.com/Mollom/MollomPHP>
 
 ## Documentation
 

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,6 @@
 	"minimum-stability": "dev",
 	"require": {
 		"silverstripe/spamprotection": "dev-master",
-		"mollom/mollom": "dev-master"
+		"mollom/client": "dev-master"
 	}
 }


### PR DESCRIPTION
Mollom module should be referred as `mollom/client` not `mollom/mollom`. See https://github.com/Mollom/MollomPHP/blob/master/composer.json.

Also updated readme with dependency.
