### PR TITLE
Fix: Mollom Dev (Testing) Mode

### DIFF
--- a/code/MollomSpamProtector.php
+++ b/code/MollomSpamProtector.php
@@ -94,16 +94,17 @@ class MollomSpamProtector extends Mollom implements SpamProtector {
 		// if the user has turned on debug mode in the Config API, change the 
 		// server to the dev version
 		if(Config::inst()->get('Mollom', 'dev')) {
-			$server = 'dev.mollom.com';
+			$server = 'http://' . 'dev.mollom.com' . '/' . Mollom::API_VERSION;
+		}
+		else {	// Mollom authentication headers should not be sent to the dev endpoint
+			// CURLOPT_HTTPHEADER expects all headers as values:
+			// @see http://php.net/manual/function.curl-setopt.php
+			foreach ($headers as $name => &$value) {
+				$value = $name . ': ' . $value;
+			}
 		}
 
 		$ch = curl_init();
-
-		// CURLOPT_HTTPHEADER expects all headers as values:
-		// @see http://php.net/manual/function.curl-setopt.php
-		foreach ($headers as $name => &$value) {
-			$value = $name . ': ' . $value;
-		}
 
 		// Compose the Mollom endpoint URL.
 		$url = $server . '/' . $path;


### PR DESCRIPTION
The Mollom testing mode was not working due to 2 issues:
1. The dev Mollom endpoint URL was missing 'http://' and '/v1'.
2. Authentication headers were being sent to the dev URL causing it to return a 401. Mollom authentication headers should not be sent to the dev server, see here: http://mollom.com/api#api-test

Both resolved in this request.
