### PR TITLE
BUGFIX: Return field title only if CAPTCHA shown

### DIFF
--- a/code/formfields/MollomField.php
+++ b/code/formfields/MollomField.php
@@ -106,6 +106,17 @@ class MollomField extends FormField {
 	}
 	
 	/**
+	 * Returns the field label if showing captcha - used by templates.
+	 * 
+	 * @return string Title if field is showing the captcha
+	 */
+	public function Title() {
+		if ($this->getShowCaptcha()) {
+			return parent::Title();
+		}
+	}
+	
+	/**
 	 * @return MollomSpamProtector
 	 */
 	public function getMollom() {


### PR DESCRIPTION
Previously the Title was displaying even when the CAPTCHA was not which makes the form look odd.
