### PR TITLE
Adding HTML5 required attribute to captcha field

### DIFF
--- a/templates/MollomField.ss
+++ b/templates/MollomField.ss
@@ -3,7 +3,7 @@
 		<div class="mollom-captcha">
 			<div class="mollom-image-captcha">
 				<img src="$Captcha" alt="Type the characters you see in this picture." />
-      			<input type="text" name="$Name" size="10" value="" autocomplete="off" />
+      			<input type="text" name="$Name" size="10" value="" autocomplete="off" required />
 			</div>
 			<!--
 			<div class="mollom-audio-captcha">


### PR DESCRIPTION
When the captcha is being displayed in a form, the field is required server-side so it is useful to make the browser impose built-in client side validation.
