### PR TITLE
Fixes #23: Comments marked as 'spam' often accepted

### DIFF
--- a/code/MollomSpamProtector.php
+++ b/code/MollomSpamProtector.php
@@ -102,6 +102,7 @@ class MollomSpamProtector extends Mollom implements SpamProtector {
 			foreach ($headers as $name => &$value) {
 				$value = $name . ': ' . $value;
 			}
+			$headers["Expect"] = "Expect:";
 		}
 
 		$ch = curl_init();


### PR DESCRIPTION
Appeared to be caused due to Mollom's server sometimes starting a response with HTTP/1.1 100 Continue causing the response to be incorrectly parsed. The fix stops Mollom returning HTTP/1.1 200 OK in the response.
