### PR TITLE
Added/fixed basic Mollom audio support

### DIFF
--- a/code/formfields/MollomField.php
+++ b/code/formfields/MollomField.php
@@ -75,10 +75,8 @@ class MollomField extends FormField {
 	 * 
 	 * @return void
 	 */
-	public function setCaptchaType($Type)
-	{
-		if (in_array($Type, array('image', 'audio')))
-		{
+	public function setCaptchaType($Type) {
+		if (in_array($Type, array('image', 'audio'))) {
 			$this->captchaType = $Type;
 		}
 	}
@@ -88,8 +86,7 @@ class MollomField extends FormField {
 	 * 
 	 * @return string
 	 */
-	public function getCaptchaType()
-	{
+	public function getCaptchaType() {
 		return $this->captchaType;
 	}
 	

--- a/code/formfields/MollomField.php
+++ b/code/formfields/MollomField.php
@@ -15,6 +15,11 @@ class MollomField extends FormField {
 	 * @var array
 	 */
 	private $fieldMapping = array();
+	
+	/**
+	 * @var string
+	 */
+	private $captchaType = 'image';
 
 	/**
 	 * @config
@@ -52,7 +57,7 @@ class MollomField extends FormField {
 			Requirements::css(MOLLOM_DIR . '/css/mollom.css');
 
 			$result = $this->getMollom()->createCaptcha(array(
-				'type' => 'image'
+				'type' => $this->getCaptchaType()
 			));
 
 			if(is_array($result)) {
@@ -64,6 +69,31 @@ class MollomField extends FormField {
 
 		return null;
 	}
+	
+	/**
+	 * Set the captcha type. Mollom supports "image" and "audio" types.
+	 * 
+	 * @return void
+	 */
+	public function setCaptchaType($Type)
+	{
+		if (in_array($Type, array('image', 'audio')))
+		{
+			$this->captchaType = $Type;
+		}
+	}
+	
+	/**
+	 * Returns the captcha type that has been set. Default is "image".
+	 * 
+	 * @return string
+	 */
+	public function getCaptchaType()
+	{
+		return $this->captchaType;
+	}
+	
+	
 
 	/**
 	 * Determines if the current user is exempt from spam detection

--- a/templates/MollomField.ss
+++ b/templates/MollomField.ss
@@ -1,13 +1,18 @@
 <% if Captcha %>
 	<% if not $isReadonly %>
 		<div class="mollom-captcha">
+			<% if $CaptchaType == "image" %>
 			<div class="mollom-image-captcha">
 				<img src="$Captcha" alt="Type the characters you see in this picture." />
       			<input type="text" name="$Name" size="10" value="" autocomplete="off" required />
 			</div>
-			<!--
+			<% else_if $CaptchaType == "audio" %>
 			<div class="mollom-audio-captcha">
-				<object classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000" codebase="//download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab#version=9,0,0,0" width="110" height="50">
+				<audio src="$Captcha" preload="auto" controls>
+					<p>Your browser does not support audio captcha</p>
+				</audio>
+				
+				<!-- <object classid="clsid:d27cdb6e-ae6d-11cf-96b8-444553540000" codebase="//download.macromedia.com/pub/shockwave/cabs/flash/swflash.cab#version=9,0,0,0" width="110" height="50">
 					<param name="allowFullScreen" value="false" />
 					<param name="movie" value="$CaptchaAudioFile" />
 					<param name="loop" value="false" />
@@ -16,9 +21,11 @@
 					<param name="wmode" value="transparent" />
 					<param name="bgcolor" value="#ffffff" />
 					<embed src="$CaptchaAudioFile" loop="false" menu="false" quality="high" wmode="transparent" bgcolor="#ffffff" width="110" height="50" align="baseline" allowScriptAccess="sameDomain" allowFullScreen="false" type="application/x-shockwave-flash" pluginspage="http://www.adobe.com/go/getflashplayer_de" />
-				</object>
+				</object> -->
+				
+      			<input type="text" name="$Name" size="10" value="" autocomplete="off" required />
 			</div>
-			-->
+			<% end_if %>
 		</div>
 	<% else %>
 		<!-- Readonly form, Mollom is hidden and we don't need to validate ever -->


### PR DESCRIPTION
Controllable via new setter/getter functions, you can tell Mollom whether to use image or audio captcha. Defaults to image captcha for backwards compatibility.

While this PR supports Mollom's audio captcha, it does not allow the user to switch between audio and image through the UI like other captcha systems. This is due to the `createCaptcha` call on MollomPHP requiring a type passed in.

My understanding would be without creating a Mollom controller (or always calling `createCaptcha` twice when loading the page, once for each type), you couldn't allow the user to switch between audio and image captcha.

I also opted for HTML5 audio rather than the flash file however left the embed source commented out as per previous commits.

With a bit of planning/discussion, another PR for implementing a user-controllable captcha type could be built on top of this.